### PR TITLE
During each export, cache results of MAnimUtil::isAnimated()

### DIFF
--- a/linux/devkit/plug-ins/AbcExport/AbcExport.cpp
+++ b/linux/devkit/plug-ins/AbcExport/AbcExport.cpp
@@ -81,6 +81,8 @@ MStatus AbcExport::doIt(const MArgList & args)
 try
 {
     MStatus status;
+    
+    util::clearIsAnimatedCache();
 
     MTime oldCurTime = MAnimControl::currentTime();
 

--- a/linux/devkit/plug-ins/AbcExport/Foundation.h
+++ b/linux/devkit/plug-ins/AbcExport/Foundation.h
@@ -91,6 +91,7 @@
 #include <maya/MItMeshVertex.h>
 #include <maya/MMatrix.h>
 #include <maya/MObjectArray.h>
+#include <maya/MObjectHandle.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
 #include <maya/MPoint.h>

--- a/linux/devkit/plug-ins/AbcExport/MayaUtility.cpp
+++ b/linux/devkit/plug-ins/AbcExport/MayaUtility.cpp
@@ -259,9 +259,28 @@ int util::getVisibilityType(const MPlug & iPlug)
     }
 }
 
+// Cache results of MAnimUtil::isAnimated(), as it can be quite slow
+// Ask Autodesk about Change Req #MAYA-43891
+typedef std::map<unsigned int, bool> IsAnimCacheMap;   // MObjectHandle.hashCode(), value=isAnimated
+static IsAnimCacheMap isAnimatedCache;                 // Is there a better place to put this??
+
+// Called by AbcExport::doIt()
+void util::clearIsAnimatedCache()
+{
+    isAnimatedCache.clear();
+}
+
 // does this cover all cases?
 bool util::isAnimated(MObject & object, bool checkParent)
 {
+    // Check the cache to see if we already know the answer.
+    const unsigned int objCacheKey = MObjectHandle(object).hashCode();
+    const IsAnimCacheMap::const_iterator cacheIter = isAnimatedCache.find(objCacheKey);
+    if (objCacheKey && (cacheIter != isAnimatedCache.end()))
+    {
+        return cacheIter->second;
+    }
+
     MStatus stat;
     MItDependencyGraph iter(object, MFn::kInvalid,
         MItDependencyGraph::kUpstream,
@@ -309,6 +328,7 @@ bool util::isAnimated(MObject & object, bool checkParent)
                 node.hasFn(MFn::kFluid) ||
                 node.hasFn(MFn::kPolyBoolOp))
         {
+            isAnimatedCache[objCacheKey] = true;
             return true;
         }
 
@@ -317,6 +337,7 @@ bool util::isAnimated(MObject & object, bool checkParent)
             MFnExpression fn(node, &stat);
             if (stat == MS::kSuccess && fn.isAnimated())
             {
+                isAnimatedCache[objCacheKey] = true;
                 return true;
             }
 		}
@@ -333,15 +354,34 @@ bool util::isAnimated(MObject & object, bool checkParent)
 		nodeStruct.checkParent = checkNodeParent;
         nodesToCheckAnimCurve.push_back(nodeStruct);
     }
-	
+
+    // The nodesToCheckAnimCurve vector can contain many duplicates, each of which
+    // may result in a slow call to MAnimUtil::isAnimated().  So, we check the 
+    // cache and update it as we go through the loop.
     for (size_t i = 0; i < nodesToCheckAnimCurve.size(); ++i)
     {
-        if (MAnimUtil::isAnimated(nodesToCheckAnimCurve[i].node, nodesToCheckAnimCurve[i].checkParent))
+        const MObject& node = nodesToCheckAnimCurve[i].node;
+        const unsigned int nodeCacheKey = MObjectHandle(node).hashCode();
+        const IsAnimCacheMap::const_iterator nodeCacheIter = isAnimatedCache.find(nodeCacheKey);
+        bool nodeIsAnimated;
+        if (nodeCacheKey && (nodeCacheIter != isAnimatedCache.end()))
         {
+            nodeIsAnimated = nodeCacheIter->second;
+        }
+        else
+        {
+            nodeIsAnimated = MAnimUtil::isAnimated(node, nodesToCheckAnimCurve[i].checkParent);
+            isAnimatedCache[nodeCacheKey] = nodeIsAnimated;
+        }
+
+        if (nodeIsAnimated)
+        {
+            isAnimatedCache[objCacheKey] = true;
             return true;
         }
     }
 
+    isAnimatedCache[objCacheKey] = false;
     return false;
 }
 

--- a/linux/devkit/plug-ins/AbcExport/MayaUtility.h
+++ b/linux/devkit/plug-ins/AbcExport/MayaUtility.h
@@ -114,6 +114,7 @@ bool getRotOrder(MTransformationMatrix::RotationOrder iOrder,
 // determine if a Maya Object is animated or not
 // copy from mayapit code (MayaPit.h .cpp)
 bool isAnimated(MObject & object, bool checkParent = false);
+void clearIsAnimatedCache();
 
 // determine if a joint is driven by FBIK.
 // The joint is animated but has no input connections.

--- a/osx/devkit/plug-ins/AbcExport/AbcExport.cpp
+++ b/osx/devkit/plug-ins/AbcExport/AbcExport.cpp
@@ -81,6 +81,8 @@ MStatus AbcExport::doIt(const MArgList & args)
 try
 {
     MStatus status;
+    
+    util::clearIsAnimatedCache();
 
     MTime oldCurTime = MAnimControl::currentTime();
 

--- a/osx/devkit/plug-ins/AbcExport/Foundation.h
+++ b/osx/devkit/plug-ins/AbcExport/Foundation.h
@@ -91,6 +91,7 @@
 #include <maya/MItMeshVertex.h>
 #include <maya/MMatrix.h>
 #include <maya/MObjectArray.h>
+#include <maya/MObjectHandle.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
 #include <maya/MPoint.h>

--- a/osx/devkit/plug-ins/AbcExport/MayaUtility.cpp
+++ b/osx/devkit/plug-ins/AbcExport/MayaUtility.cpp
@@ -259,9 +259,28 @@ int util::getVisibilityType(const MPlug & iPlug)
     }
 }
 
+// Cache results of MAnimUtil::isAnimated(), as it can be quite slow
+// Ask Autodesk about Change Req #MAYA-43891
+typedef std::map<unsigned int, bool> IsAnimCacheMap;   // MObjectHandle.hashCode(), value=isAnimated
+static IsAnimCacheMap isAnimatedCache;                 // Is there a better place to put this??
+
+// Called by AbcExport::doIt()
+void util::clearIsAnimatedCache()
+{
+    isAnimatedCache.clear();
+}
+
 // does this cover all cases?
 bool util::isAnimated(MObject & object, bool checkParent)
 {
+    // Check the cache to see if we already know the answer.
+    const unsigned int objCacheKey = MObjectHandle(object).hashCode();
+    const IsAnimCacheMap::const_iterator cacheIter = isAnimatedCache.find(objCacheKey);
+    if (objCacheKey && (cacheIter != isAnimatedCache.end()))
+    {
+        return cacheIter->second;
+    }
+
     MStatus stat;
     MItDependencyGraph iter(object, MFn::kInvalid,
         MItDependencyGraph::kUpstream,
@@ -309,6 +328,7 @@ bool util::isAnimated(MObject & object, bool checkParent)
                 node.hasFn(MFn::kFluid) ||
                 node.hasFn(MFn::kPolyBoolOp))
         {
+            isAnimatedCache[objCacheKey] = true;
             return true;
         }
 
@@ -317,6 +337,7 @@ bool util::isAnimated(MObject & object, bool checkParent)
             MFnExpression fn(node, &stat);
             if (stat == MS::kSuccess && fn.isAnimated())
             {
+                isAnimatedCache[objCacheKey] = true;
                 return true;
             }
 		}
@@ -333,15 +354,34 @@ bool util::isAnimated(MObject & object, bool checkParent)
 		nodeStruct.checkParent = checkNodeParent;
         nodesToCheckAnimCurve.push_back(nodeStruct);
     }
-	
+
+    // The nodesToCheckAnimCurve vector can contain many duplicates, each of which
+    // may result in a slow call to MAnimUtil::isAnimated().  So, we check the 
+    // cache and update it as we go through the loop.
     for (size_t i = 0; i < nodesToCheckAnimCurve.size(); ++i)
     {
-        if (MAnimUtil::isAnimated(nodesToCheckAnimCurve[i].node, nodesToCheckAnimCurve[i].checkParent))
+        const MObject& node = nodesToCheckAnimCurve[i].node;
+        const unsigned int nodeCacheKey = MObjectHandle(node).hashCode();
+        const IsAnimCacheMap::const_iterator nodeCacheIter = isAnimatedCache.find(nodeCacheKey);
+        bool nodeIsAnimated;
+        if (nodeCacheKey && (nodeCacheIter != isAnimatedCache.end()))
         {
+            nodeIsAnimated = nodeCacheIter->second;
+        }
+        else
+        {
+            nodeIsAnimated = MAnimUtil::isAnimated(node, nodesToCheckAnimCurve[i].checkParent);
+            isAnimatedCache[nodeCacheKey] = nodeIsAnimated;
+        }
+
+        if (nodeIsAnimated)
+        {
+            isAnimatedCache[objCacheKey] = true;
             return true;
         }
     }
 
+    isAnimatedCache[objCacheKey] = false;
     return false;
 }
 

--- a/osx/devkit/plug-ins/AbcExport/MayaUtility.h
+++ b/osx/devkit/plug-ins/AbcExport/MayaUtility.h
@@ -114,6 +114,7 @@ bool getRotOrder(MTransformationMatrix::RotationOrder iOrder,
 // determine if a Maya Object is animated or not
 // copy from mayapit code (MayaPit.h .cpp)
 bool isAnimated(MObject & object, bool checkParent = false);
+void clearIsAnimatedCache();
 
 // determine if a joint is driven by FBIK.
 // The joint is animated but has no input connections.

--- a/win/devkit/plug-ins/AbcExport/AbcExport.cpp
+++ b/win/devkit/plug-ins/AbcExport/AbcExport.cpp
@@ -82,6 +82,8 @@ try
 {
     MStatus status;
 
+    util::clearIsAnimatedCache();
+
     MTime oldCurTime = MAnimControl::currentTime();
 
     MArgParser argData(syntax(), args, &status);

--- a/win/devkit/plug-ins/AbcExport/Foundation.h
+++ b/win/devkit/plug-ins/AbcExport/Foundation.h
@@ -91,6 +91,7 @@
 #include <maya/MItMeshVertex.h>
 #include <maya/MMatrix.h>
 #include <maya/MObjectArray.h>
+#include <maya/MObjectHandle.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
 #include <maya/MPoint.h>

--- a/win/devkit/plug-ins/AbcExport/MayaUtility.h
+++ b/win/devkit/plug-ins/AbcExport/MayaUtility.h
@@ -114,6 +114,7 @@ bool getRotOrder(MTransformationMatrix::RotationOrder iOrder,
 // determine if a Maya Object is animated or not
 // copy from mayapit code (MayaPit.h .cpp)
 bool isAnimated(MObject & object, bool checkParent = false);
+void clearIsAnimatedCache();
 
 // determine if a joint is driven by FBIK.
 // The joint is animated but has no input connections.


### PR DESCRIPTION
MAnimUtil::isAnimated() may get called a lot by MayaUtils::isAnimated(), which is in turn called for every object and for every timesample.  This can cause exports to get quite slow, especially for certain cases with large numbers of animated plug networks.  It stands to reason that whether or not a plug is animated does not change during the course of an export, so we can cache it.  Under some conditions, this can be a huge time savings--from 20 minutes down to 30 seconds for a single-frame export in one case.